### PR TITLE
IConverterSettings simplified; DownloadMethod issue resolved

### DIFF
--- a/SourceCodes/03_Services/CloudConvert.Wrapper/CloudConvert.Wrapper.csproj
+++ b/SourceCodes/03_Services/CloudConvert.Wrapper/CloudConvert.Wrapper.csproj
@@ -57,6 +57,7 @@
     <Compile Include="ConfigElements\ApiKeyElement.cs" />
     <Compile Include="ConfigElements\BasicElement.cs" />
     <Compile Include="ConverterSettings.cs" />
+    <Compile Include="Converters\DownloadMethodConverter.cs" />
     <Compile Include="Exceptions\ErrorResponseException.cs" />
     <Compile Include="Extensions\AutoMapperExtension.cs" />
     <Compile Include="Interfaces\IConverterSettings.cs" />

--- a/SourceCodes/03_Services/CloudConvert.Wrapper/ConverterSettings.cs
+++ b/SourceCodes/03_Services/CloudConvert.Wrapper/ConverterSettings.cs
@@ -23,6 +23,45 @@ namespace Aliencube.CloudConvert.Wrapper
         }
 
         /// <summary>
+        /// Gets the process URL.
+        /// </summary>
+        public string ProcessUrl
+        {
+            get { return this.Basic.ProcessUrl; }
+            set
+            {
+                if (this.Basic != null)
+                    this.Basic.ProcessUrl = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets the value that specifies whether to include the API key in the header or not.
+        /// </summary>
+        public bool UseHeader
+        {
+            get { return this.Basic.UseHeader; }
+            set
+            {
+                if (this.Basic != null)
+                    this.Basic.UseHeader = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets the ApiKey value
+        /// </summary>
+        public string ApiKey
+        {
+            get { return this.Basic?.ApiKey?.Value; }
+            set
+            {
+                if (this.Basic != null)
+                    this.Basic.ApiKey.Value = value;
+            }
+        }
+
+        /// <summary>
         /// Creates a new instance of the <c>ConverterSettings</c> class.
         /// </summary>
         /// <returns>Returns the new instance of the <c>ConverterSettings</c> class.</returns>
@@ -64,17 +103,17 @@ namespace Aliencube.CloudConvert.Wrapper
             }
 
             var settings = new ConverterSettings
-                           {
-                               Basic = new BasicElement
-                                       {
-                                           ProcessUrl = processUrl,
-                                           UseHeader = useHeader,
-                                           ApiKey = new ApiKeyElement
-                                                    {
-                                                        Value = apiKey,
-                                                    },
-                                       }
-                           };
+            {
+                Basic = new BasicElement
+                {
+                    ProcessUrl = processUrl,
+                    UseHeader = useHeader,
+                    ApiKey = new ApiKeyElement
+                    {
+                        Value = apiKey,
+                    },
+                }
+            };
             return settings;
         }
 

--- a/SourceCodes/03_Services/CloudConvert.Wrapper/ConverterWrapper.cs
+++ b/SourceCodes/03_Services/CloudConvert.Wrapper/ConverterWrapper.cs
@@ -51,7 +51,7 @@ namespace Aliencube.CloudConvert.Wrapper
                   .ForMember(d => d.Email, o => o.MapFrom(s => s.Email ? s.Email : (bool?)null))
                   .ForMember(d => d.OutputStorage, o => o.MapFrom(s => s.OutputStorage != OutputStorage.None ? s.OutputStorage.ToLower() : null))
                   .ForMember(d => d.Wait, o => o.MapFrom(s => s.Wait ? s.Wait : (bool?)null))
-                  .ForMember(d => d.DownloadMethod, o => o.MapFrom(s => s.DownloadMethod.ToLower()))
+                  //.ForMember(d => d.DownloadMethod, o => o.MapFrom(s => s.DownloadMethod.ToLower()))
                   .ForMember(d => d.SaveToServer, o => o.MapFrom(s => s.SaveToServer ? s.SaveToServer : (bool?)null));
             Mapper.CreateMap<ConversionParameters, ConvertRequest>()
                   .ForMember(d => d.Timeout, o => o.MapFrom(s => s.Timeout > 0 ? s.Timeout : (int?)null));
@@ -110,10 +110,10 @@ namespace Aliencube.CloudConvert.Wrapper
             ProcessResponse deserialised;
             using (var client = new HttpClient())
             {
-                var apiKey = this._settings.Basic.ApiKey.Value;
-                var processUrl = this._settings.Basic.ProcessUrl;
+                var apiKey = this._settings.ApiKey;
+                var processUrl = this._settings.ProcessUrl;
 
-                if (this._settings.Basic.UseHeader)
+                if (this._settings.UseHeader)
                 {
                     client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
                 }

--- a/SourceCodes/03_Services/CloudConvert.Wrapper/Converters/DownloadMethodConverter.cs
+++ b/SourceCodes/03_Services/CloudConvert.Wrapper/Converters/DownloadMethodConverter.cs
@@ -1,0 +1,46 @@
+﻿using Aliencube.CloudConvert.Wrapper.Options;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Aliencube.CloudConvert.Wrapper.Converters
+{
+    public class DownloadMethodConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(DownloadMethod);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var item = (DownloadMethod)value;
+
+            switch (item)
+            {
+                case DownloadMethod.None:
+                    writer.WriteUndefined();
+                    break;
+                case DownloadMethod.True:
+                    writer.WriteValue(true);
+                    break;
+                case DownloadMethod.False:
+                    writer.WriteValue(false);
+                    break;
+                default:
+                    writer.WriteValue(item.ToString());
+                    break;
+            }
+
+            writer.Flush();
+        }
+    }
+}

--- a/SourceCodes/03_Services/CloudConvert.Wrapper/Interfaces/IConverterSettings.cs
+++ b/SourceCodes/03_Services/CloudConvert.Wrapper/Interfaces/IConverterSettings.cs
@@ -9,8 +9,18 @@ namespace Aliencube.CloudConvert.Wrapper.Interfaces
     public interface IConverterSettings : IDisposable
     {
         /// <summary>
-        /// Gets or sets the basic element.
+        /// Gets the process URL.
         /// </summary>
-        BasicElement Basic { get; set; }
+        string ProcessUrl { get; }
+
+        /// <summary>
+        /// Gets the value that specifies whether to include the API key in the header or not.
+        /// </summary>
+        bool UseHeader { get; }
+
+        /// <summary>
+        /// Gets the ApiKey value
+        /// </summary>
+        string ApiKey { get; }
     }
 }

--- a/SourceCodes/03_Services/CloudConvert.Wrapper/Options/DownloadMethod.cs
+++ b/SourceCodes/03_Services/CloudConvert.Wrapper/Options/DownloadMethod.cs
@@ -6,6 +6,11 @@ namespace Aliencube.CloudConvert.Wrapper.Options
     public enum DownloadMethod
     {
         /// <summary>
+        /// Do not specify the download property in the request
+        /// </summary>
+        None,
+
+        /// <summary>
         /// Specifies no download is allowed.
         /// </summary>
         False,

--- a/SourceCodes/03_Services/CloudConvert.Wrapper/Options/OutputParameters.cs
+++ b/SourceCodes/03_Services/CloudConvert.Wrapper/Options/OutputParameters.cs
@@ -1,3 +1,6 @@
+using Aliencube.CloudConvert.Wrapper.Converters;
+using Newtonsoft.Json;
+
 namespace Aliencube.CloudConvert.Wrapper.Options
 {
     /// <summary>
@@ -29,6 +32,7 @@ namespace Aliencube.CloudConvert.Wrapper.Options
         /// Gets or sets the value whether to wailt/block request until the conversion is over.
         /// </summary>
         /// <remarks>If the value is <c>true</c>, the file download immediately starts, when the conversion is completed.</remarks>
+        [JsonConverter(typeof(DownloadMethodConverter))]
         public DownloadMethod DownloadMethod { get; set; }
 
         /// <summary>

--- a/SourceCodes/03_Services/CloudConvert.Wrapper/Requests/ConvertRequest.cs
+++ b/SourceCodes/03_Services/CloudConvert.Wrapper/Requests/ConvertRequest.cs
@@ -1,3 +1,5 @@
+using Aliencube.CloudConvert.Wrapper.Converters;
+using Aliencube.CloudConvert.Wrapper.Options;
 using Newtonsoft.Json;
 
 namespace Aliencube.CloudConvert.Wrapper.Requests
@@ -79,7 +81,8 @@ namespace Aliencube.CloudConvert.Wrapper.Requests
         /// </summary>
         /// <remarks>If the value is <c>true</c>, the file download immediately starts, when the conversion is completed.</remarks>
         [JsonProperty(PropertyName = "Download")]
-        public string DownloadMethod { get; set; }
+        [JsonConverter(typeof(DownloadMethodConverter))]
+        public DownloadMethod DownloadMethod { get; set; }
 
         /// <summary>
         /// Gets or sets the value whether to save the converted file on CloudConvert.com or not.

--- a/SourceCodes/03_Services/CloudConvert.Wrapper/Requests/ConvertRequestSerialiseOptions.cs
+++ b/SourceCodes/03_Services/CloudConvert.Wrapper/Requests/ConvertRequestSerialiseOptions.cs
@@ -94,7 +94,7 @@ namespace Aliencube.CloudConvert.Wrapper.Requests
         /// <returns>Returns <c>True</c>, if the <c>DownloadMethod</c> property is not null; otherwise returns <c>False</c>.</returns>
         public bool ShouldSerializeDownloadMethod()
         {
-            return !String.IsNullOrWhiteSpace(this.DownloadMethod);
+            return this.DownloadMethod != Options.DownloadMethod.None;
         }
 
         /// <summary>

--- a/SourceCodes/99_Tests/CloudConvert.Tests/CloudConvert.Tests.csproj
+++ b/SourceCodes/99_Tests/CloudConvert.Tests/CloudConvert.Tests.csproj
@@ -92,6 +92,9 @@
       <Name>CloudConvert.Wrapper</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/SourceCodes/99_Tests/CloudConvert.Tests/ConverterSettingsTest.cs
+++ b/SourceCodes/99_Tests/CloudConvert.Tests/ConverterSettingsTest.cs
@@ -5,6 +5,9 @@ using NUnit.Framework;
 
 namespace Aliencube.CloudConvert.Tests
 {
+    /// <summary>
+    /// Tests Converter Settings from Configuration File
+    /// </summary>
     [TestFixture]
     public class ConverterSettingsTest
     {
@@ -28,17 +31,17 @@ namespace Aliencube.CloudConvert.Tests
         [Test]
         public void GetConverterSettings_GivenConfig_ReturnConverterSettings()
         {
-            var basic = this._settings.Basic;
-            basic.Should().NotBeNull();
+            //var basic = this._settings.Basic;
+            //basic.Should().NotBeNull();
 
-            var processUrl = basic.ProcessUrl;
+            var processUrl = _settings.ProcessUrl;
             processUrl.Should().NotBeNullOrWhiteSpace();
 
-            var useHeader = basic.UseHeader;
+            var useHeader = _settings.UseHeader;
             useHeader.Should().BeTrue();
 
-            var apiKey = basic.ApiKey;
-            apiKey.Value.Should().NotBeNullOrWhiteSpace();
+            var apiKey = _settings.ApiKey;
+            apiKey.Should().NotBeNullOrWhiteSpace();
         }
     }
 }


### PR DESCRIPTION
@justinyoo , thanks for that great CloudConverter Wrapper.
I've found some issues (listed below) with Settings and DownloadMethod and I've tried to resolve them. If You would find my changes useful and reliable, please commit them in the project.
Anyway, I would appreciate Your feedback.

Best regards,
  Ivan Litskevich.
## IConverterSettings simplified

  The issue was, that the only way to specify settings was to have .config with appropriate settings.

Now there is no need to have config requirement, because we may use any ConverterSettings class (nested by IConverterSettings) that can be created not from .config, but i.e. from DB or dynamically from the code. Only requirement for that class - is to have 3 main properties (ApiKey, ProcessUrl and UseHeader).
## DownloadMethod issue resolved

  The issue was, that some values (true or false) were serialized as a string (i.e.: "download":"false"), that caused wrong server-side interpretation (these values wasn't parsed on the server correctly and in some cases in response we could have a converted file - wrong behavior).

Now DownloadMethod sends correctly (as bool or as string) depending on the value (thanks to Json Custom Serialization attribute option).
